### PR TITLE
Add retain option and porting to new buffer API according to deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,4 @@ In cases where requests match multiple or all usecases (eg: sending a post reque
 |`MQTT_CLIENT_ID`|`null`| MQTT Client ID (optional).|
 |`MQTT_USERNAME`|`null`| MQTT Username (optional).|
 |`MQTT_PASSWORD`|`null`| MQTT Password (optional).|
+|`MQTT_RETAIN`|`false`| Set `true` to retain messages in MQTT (optional).|

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "ht2mq",
-  "version": "1.0.0",
+  "version": "1.1.0",
+  "license": "MIT",
   "dependencies": {
-    "mqtt": "^3.0.0"
+    "mqtt": "^4.3.7"
   }
 }

--- a/src/http.js
+++ b/src/http.js
@@ -50,15 +50,14 @@ exports.create = ({publish}) => {
           const {topic, payload} = await extractTopicAndPayload(req);
           const result = await publish(topic, payload)
 
-          buffer = new Buffer(JSON.stringify({
+          buffer = Buffer.from(JSON.stringify({
             topic, payload, result
           }), "utf8");
 
           res.writeHead(200, {'Content-Type': 'application/json', 'Content-Length': buffer.length})
-          res.end(buffer);
 
         } catch (e) {
-          buffer = new Buffer(JSON.stringify({error: e.message}), "utf8")
+          buffer = Buffer.from(JSON.stringify({error: e.message}), "utf8")
           res.writeHead(500, {'Content-Type': 'application/json', 'Content-Length': buffer.length})
         } finally {
           res.end(buffer);

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ const {
   MQTT_CLIENT_ID = null,
   MQTT_USERNAME = null,
   MQTT_PASSWORD = null,
+  MQTT_RETAIN = false,
 } = process.env;
 
 
@@ -22,6 +23,7 @@ MQTT
     })
     .then((client) => {
       console.log("[MQTT] Connected to %j", MQTT_BROKER);
+      console.log("[MQTT] retain: ", MQTT_RETAIN);
       return HTTP.create({
             publish: (topic, payload) => {
               return new Promise((resolve, reject) => {
@@ -29,7 +31,7 @@ MQTT
                   reject(new Error('Refusing to publish to empty topic'))
                 } else {
                   const prefixedTopic = `${ TOPIC_PREFIX }${ topic }`
-                  client.publish(prefixedTopic, payload, (error => {
+                  client.publish(prefixedTopic, payload, { retain: MQTT_RETAIN }, (error => {
                     const errorMessage = error && error.message;
                     resolve({
                       success: !errorMessage,


### PR DESCRIPTION
First of all thank you for writing this seemingly simple yet super useful bridge!

I needed the messages to be retained so I added an option for it. Also since I already was changing stuff, I got rid of the deprecation warning for the buffers by porting them to the new API according to [here](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation).

Just FYI: I also wanted to add an QoS option, but that messed up the payload somehow?! It always appended bytes `31 EF BF BD` after the json string. I tried to debug it but had no luck and gave up.